### PR TITLE
Реорганизация импортов стилей

### DIFF
--- a/public/initialStyles.css
+++ b/public/initialStyles.css
@@ -1,0 +1,37 @@
+@font-face {
+    font-family: "ALS_Sector";
+    src: url("/src/shared/fonts/ALS_Sector.eot");
+    src: url("/src/shared/fonts/ALS_Sector.eot?#iefix")format("embedded-opentype"),
+    url("/src/shared/fonts/ALS_Sector.woff2")format("woff2"),
+    url("/src/shared/fonts/ALS_Sector.woff")format("woff"),
+    url("/src/shared/fonts/ALS_Sector.ttf")format("truetype"),
+    url("/src/shared/fonts/ALS_Sector.svg#ALS Sector Regular Regular")format("svg");
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: "ALS_Sector", sans-serif;
+}
+
+html {
+    background-color: var(--site-background);
+}
+
+body {
+    margin: 0;
+    min-height: 100%;
+}
+
+#root {
+    min-height: 100vh;
+}
+
+.container {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    min-height: 100vh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,41 +1,4 @@
 @import url("globalVariables.css");
+@import url("initialStyles.css");
 @import url("../src/components/index.css");
 @import url("../src/pages/index.css");
-
-@font-face {
-    font-family: "ALS_Sector";
-    src: url("/src/shared/fonts/ALS_Sector.eot");
-    src: url("/src/shared/fonts/ALS_Sector.eot?#iefix")format("embedded-opentype"),
-        url("/src/shared/fonts/ALS_Sector.woff2")format("woff2"),
-        url("/src/shared/fonts/ALS_Sector.woff")format("woff"),
-        url("/src/shared/fonts/ALS_Sector.ttf")format("truetype"),
-        url("/src/shared/fonts/ALS_Sector.svg#ALS Sector Regular Regular")format("svg");
-}
-
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    font-family: "ALS_Sector";
-}
-
-html {
-    background-color: var(--site-background);
-}
-
-body {
-    margin: 0;
-    min-height: 100%;
-}
-
-#root {
-    min-height: 100vh;
-    /*width: var(--max-width);
-    margin: 0 auto;*/
-}
-
-.container {
-    min-height: 100vh;
-    display: grid;
-    grid-template-rows: auto 1fr auto;
-}

--- a/src/pages/regPage/regPage.css
+++ b/src/pages/regPage/regPage.css
@@ -1,3 +1,7 @@
+html {
+    background-color: var(--background);
+}
+
 .reg_page {
     height: 100%;
     display: flex;


### PR DESCRIPTION
Все базовые стили вынесены в файл `initialStyels.css`, который подключается перед всеми остальными стилями. Нужно это для того, чтобы иметь возможность переопределять стартовые стили. Например, это понадобилось на странице с регистрацией, у которой  нет шапки и подвала.